### PR TITLE
Summary style text for input labels, legends and select options

### DIFF
--- a/specifications/definition/fieldset/definition.fieldset.schema.json
+++ b/specifications/definition/fieldset/definition.fieldset.schema.json
@@ -14,6 +14,12 @@
       "type": "string",
       "content": true
     },
+    "summaryLegend": {
+      "title": "Summary Legend",
+      "description": "The text used on the 'check your answers' page. Ideally a shorter version of the legend text",
+      "type": "string",
+      "content": true
+    },
     "hint": {
       "title": "Hint text",
       "description": "Text to help users answer a question - appears in grey under the legend (like this text)",

--- a/specifications/definition/label/definition.label.schema.json
+++ b/specifications/definition/label/definition.label.schema.json
@@ -16,6 +16,12 @@
       "type": "string",
       "multiline": true,
       "content": true
+    },
+    "summaryLabel": {
+      "title": "Summary Label",
+      "description": "The text used on the 'check your answers' page. Ideally a shorter version of the label text",
+      "type": "string",
+      "content": true
     }
   },
   "category": [

--- a/specifications/option/option.schema.json
+++ b/specifications/option/option.schema.json
@@ -14,6 +14,12 @@
       "type": "string",
       "content": true
     },
+    "summaryText": {
+      "title": "Summary option text",
+      "description": "Text displayed to users on the 'check your answers' page. Ideally a simplified version of the option text",
+      "type": "string",
+      "content": true
+    },
     "value": {
       "title": "Option value",
       "description": "Value assigned when users select option",


### PR DESCRIPTION
Have thoroughly tested this!

<img width="703" alt="Screen Shot 2019-05-02 at 2 20 36 PM" src="https://user-images.githubusercontent.com/381495/57080117-c92f2280-6ce9-11e9-8ae2-310f5582042f.png">

One thing I'm not too sure about is why the regular label text is appearing on the 'summary label' editor page. Let me know if you have any thoughts @solidgoldpig 