### PR TITLE
Adds summary headings to schema definition

### DIFF
--- a/specifications/definition/fieldset/definition.fieldset.schema.json
+++ b/specifications/definition/fieldset/definition.fieldset.schema.json
@@ -14,8 +14,8 @@
       "type": "string",
       "content": true
     },
-    "summaryLegend": {
-      "title": "Summary Legend",
+    "legendSummary": {
+      "title": "Legend Summary",
       "description": "The text used on the 'check your answers' page. Ideally a shorter version of the legend text",
       "type": "string",
       "content": true

--- a/specifications/definition/fieldset/definition.fieldset.schema.json
+++ b/specifications/definition/fieldset/definition.fieldset.schema.json
@@ -15,7 +15,7 @@
       "content": true
     },
     "legendSummary": {
-      "title": "Legend Summary",
+      "title": "Legend (Summary version)",
       "description": "The text used on the 'check your answers' page. Ideally a shorter version of the legend text",
       "type": "string",
       "content": true

--- a/specifications/definition/label/definition.label.schema.json
+++ b/specifications/definition/label/definition.label.schema.json
@@ -18,7 +18,7 @@
       "content": true
     },
     "labelSummary": {
-      "title": "Label Summary",
+      "title": "Label (Summary version)",
       "description": "The text used on the 'check your answers' page. Ideally a shorter version of the label text",
       "type": "string",
       "content": true

--- a/specifications/definition/label/definition.label.schema.json
+++ b/specifications/definition/label/definition.label.schema.json
@@ -17,8 +17,8 @@
       "multiline": true,
       "content": true
     },
-    "summaryLabel": {
-      "title": "Summary Label",
+    "labelSummary": {
+      "title": "Label Summary",
       "description": "The text used on the 'check your answers' page. Ideally a shorter version of the label text",
       "type": "string",
       "content": true

--- a/specifications/definition/page/form/definition.page.form.schema.json
+++ b/specifications/definition/page/form/definition.page.form.schema.json
@@ -26,6 +26,24 @@
         "content"
       ]
     },
+    "summarySectionHeading": {
+      "title": "Summary section heading",
+      "description": "A condensed version of the section heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "summaryHeading": {
+      "title": "Summary heading",
+      "description": "A condensed version of the page heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
     "stepsHeading": {
       "title": "Steps heading",
       "description": "Name of section to use on step pages (if any)",

--- a/specifications/definition/page/form/definition.page.form.schema.json
+++ b/specifications/definition/page/form/definition.page.form.schema.json
@@ -26,8 +26,8 @@
         "content"
       ]
     },
-    "summarySectionHeading": {
-      "title": "Summary section heading",
+    "sectionHeadingSummary": {
+      "title": "Section heading Summary",
       "description": "A condensed version of the section heading, for use on the 'check your answers' page",
       "type": "string",
       "content": true,
@@ -35,8 +35,8 @@
         "content"
       ]
     },
-    "summaryHeading": {
-      "title": "Summary heading",
+    "headingSummary": {
+      "title": "Heading Summary",
       "description": "A condensed version of the page heading, for use on the 'check your answers' page",
       "type": "string",
       "content": true,

--- a/specifications/definition/page/form/definition.page.form.schema.json
+++ b/specifications/definition/page/form/definition.page.form.schema.json
@@ -27,7 +27,7 @@
       ]
     },
     "sectionHeadingSummary": {
-      "title": "Section heading Summary",
+      "title": "Section heading (Summary version)",
       "description": "A condensed version of the section heading, for use on the 'check your answers' page",
       "type": "string",
       "content": true,
@@ -36,7 +36,7 @@
       ]
     },
     "headingSummary": {
-      "title": "Heading Summary",
+      "title": "Heading (Summary version)",
       "description": "A condensed version of the page heading, for use on the 'check your answers' page",
       "type": "string",
       "content": true,

--- a/specifications/option/option.schema.json
+++ b/specifications/option/option.schema.json
@@ -15,7 +15,7 @@
       "content": true
     },
     "textSummary": {
-      "title": "Text Summary for an option",
+      "title": "Option text (Summary version)",
       "description": "Text displayed to users on the 'check your answers' page. Ideally a simplified version of the option text",
       "type": "string",
       "content": true

--- a/specifications/option/option.schema.json
+++ b/specifications/option/option.schema.json
@@ -14,8 +14,8 @@
       "type": "string",
       "content": true
     },
-    "summaryText": {
-      "title": "Summary option text",
+    "textSummary": {
+      "title": "Text Summary for an option",
       "description": "Text displayed to users on the 'check your answers' page. Ideally a simplified version of the option text",
       "type": "string",
       "content": true


### PR DESCRIPTION
Note. Page headings are actually defined in `definition.page.schema.json`, however I think summary headings are only relevant to forms which is why I put it here. Let me know what you think!