### PR TITLE
Add upload info when no slots available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-components-core",
-  "version": "0.0.146-22",
+  "version": "0.0.146-27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "condition"
     ]
   },
-  "version": "0.0.146-26",
+  "version": "0.0.146-27",
   "description": "Form Builder core components",
   "main": "index.js",
   "scripts": {

--- a/specifications/fileupload/template/nunjucks/fileupload.njk
+++ b/specifications/fileupload/template/nunjucks/fileupload.njk
@@ -103,13 +103,14 @@
       <div class="fb-form--fileupload-single">
       {{ govukFileUpload(uploadParams) }}
       </div>
-      {{ uploadAdditonalParts(params) }}
+      
     {% else %}
       <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
         {{ govukLabel(params.label) }}
         {{ innerHtml | trim | safe }}
       </div>
     {% endif %}
+    {{ uploadAdditonalParts(params) }}
   {% endif %}
 
 {% endmacro -%}


### PR DESCRIPTION
Upload info was only being displayed if maximum number of files to be uploaded had not been reached