### PR TITLE
Add new configuration option to attach submission info to user email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-components-core",
-  "version": "3.0.0-1",
+  "version": "3.0.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "condition"
     ]
   },
-  "version": "3.0.0-1",
+  "version": "3.0.0-2",
   "description": "Form Builder core components",
   "main": "index.js",
   "scripts": {

--- a/specifications/config/service/config.service.schema.json
+++ b/specifications/config/service/config.service.schema.json
@@ -62,6 +62,11 @@
       "description": "Name of input used as email address to send user a copy of submission details",
       "type": "string"
     },
+    "attachUserSubmission": {
+      "title": "Attach confirmation of submission to user email",
+      "type": "boolean",
+      "default": false
+    },
     "emailSubjectUser": {
       "title": "CC email subject",
       "type": "string"


### PR DESCRIPTION
There is no need to attach a user's submission to the email we send them.
It also carries a risk that a miss-typed email address would deliver all this
data to the wrong person.  This functionality is off by default, unless configured.