### PR TITLE
remove accept attribute from file upload

### DIFF
--- a/specifications/fileupload/template/nunjucks/fileupload.njk
+++ b/specifications/fileupload/template/nunjucks/fileupload.njk
@@ -7,9 +7,6 @@
   {% set params = setInputWidthClass(params) %}
 
   {% set attributes = params.attributes %}
-  {% if params.accept %}
-    {% set attributes = setObject(attributes, {accept: params.accept}) %}
-  {% endif %}
 
   {% if params.maxFiles > 1 or not params.slots %}
     {#- If an id 'prefix' is not passed, fall back to using the name attribute


### PR DESCRIPTION
this way users are free to upload any files they wish
the server will handle the uploaded file and return appropriate error
message back to the user