### PR TITLE
fix Welsh cookie message syntax error

### DIFF
--- a/metadata/string/cookies.message.value.json
+++ b/metadata/string/cookies.message.value.json
@@ -3,5 +3,5 @@
   "_type": "string",
   "description": "Message displayed to user to notify them of the use of cookies",
   "value": "We use cookies to make the site simpler. [Find out more about cookies]([% url:page.cookies %])",
-  "value:cy": "Rydym yn defnyddio cwcis i wneud y safle'n symlach. [Darganfyddwch fwy am cwcis](% url:page.cookies %])"
+  "value:cy": "Rydym yn defnyddio cwcis i wneud y safle'n symlach. [Darganfyddwch fwy am cwcis]([% url:page.cookies %])"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-components-core",
-  "version": "3.1.0-1",
+  "version": "3.1.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "condition"
     ]
   },
-  "version": "3.1.0-1",
+  "version": "3.1.0-2",
   "description": "Form Builder core components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
otherwise is not processed by markdown
and user sees internal syntax